### PR TITLE
:sparkles: Feat: 모든 페이지의 header의 사용자 이미지와 닉네임 추가

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,11 +8,10 @@ console.log(data);
 
 access_token = data['access_token'];
 
-localStorage.setItem('access_tokens', JSON.stringify(data.access_token));
-localStorage.setItem('refresh_tokens', JSON.stringify(data.refresh_token));
+localStorage.setItem('access_tokens', data.access_token);
+localStorage.setItem('refresh_tokens', data.refresh_token);
 
 // 접속중인 사용자 확인
-
 fetch('http://43.202.230.2/users/info', {
   method: 'GET',
   headers: {

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -1,3 +1,7 @@
+const BASEURL = 'http://43.202.230.2';
+const userImg = document.querySelector('.user-img');
+const userNickname = document.querySelector('.user-nickname');
+
 function previewImage() {
   const input = document.querySelector('#imageUpload');
   if (input.files && input.files[0]) {
@@ -18,3 +22,18 @@ function removeSelectedFile() {
   preview.style.backgroundImage = 'none';
 }
 
+const token = localStorage.getItem('access_tokens');
+
+fetch(`${BASEURL}/users/info`, {
+  method: 'GET',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`
+  },
+}).then(response => response.json())
+  .then(data => {
+    const imageUrl = data.user['profile_img'].includes('k.kakaocdn.net') ?
+      data.user['profile_img'].replace('/media/http%3A/', 'http://') : `${BASEURL}${data.user['profile_img']}`;
+    userImg.style.backgroundImage = `url(${imageUrl})`;
+    userNickname.textContent = data.user['nickname'];
+  })


### PR DESCRIPTION
- 토큰값을 받아오지 못해 main.js에 localStroage하는 부분 변경
- 모든 페이지의 header에서 사용자 이미지와 닉네임을 불러옴(scripts)
- scripts를 갖는 모든 페이지는 token 변수로 엑세스 토큰 받기 가능
- BASEURL 변수 설정, scripts를 갖는 모든 페이지는 BASEURL변수로 값 요청 가능