### PR TITLE
✨ Feat: 유저 프로필 다른사람 조회 및 팔로우 요청

### DIFF
--- a/src/css/user.css
+++ b/src/css/user.css
@@ -28,7 +28,8 @@
   min-width: 50%;
 }
 
-.edit-btn {
+.edit-btn,
+.follow-btn {
   width: 100%;
 }
 

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -32,14 +32,20 @@ fetch(`${BASEURL}/users/info`, {
   },
 }).then(response => response.json())
   .then(data => {
-    const imageUrl = data.user['profile_img'].includes('k.kakaocdn.net') ?
-      data.user['profile_img'].replace('/media/http%3A/', 'http://') : `${BASEURL}${data.user['profile_img']}`;
-    userImg.style.backgroundImage = `url(${imageUrl})`;
+    document.querySelector('.user-profile a').href = `./user.html?user_id=${data.user_id}`;
+    if (data.user['profile_img']) {
+      const imageUrl = data.user['profile_img'].includes('k.kakaocdn.net') ?
+        data.user['profile_img'].replace('/media/http%3A/', 'http://') : `${BASEURL}${data.user['profile_img']}`;
+      userImg.style.backgroundImage = `url(${imageUrl})`;
+    }
     userNickname.textContent = data.user['nickname'];
   })
   .catch(error => {
     // 요청 실패 시 에러 처리
     console.error('프로필 정보를 가져오지 못했습니다:', error);
     //확인 알림창
-    confirm('프로필을 가져오지 못했습니다. 새로고침하거나 로그인을 해주세요.');
+    const isOk = confirm('사용자 정보가 없습니다. 로그인 페이지로 이동합니다.');
+    if (isOk) {
+      window.location.href = './login.html';
+    }
   });

--- a/src/js/user.js
+++ b/src/js/user.js
@@ -4,8 +4,14 @@ const followerNum = document.querySelector('.follower-num');
 const followingNum = document.querySelector('.following-num');
 const introBox = document.querySelector('.intro-box');
 const listContainer = document.querySelector('.list-container');
+const followButton = document.querySelector('.follow-btn');
+const followersLink = document.querySelector('.followers a');
+const followsingsLink = document.querySelector('.followings a');
 
-let userId = 0
+const params = new URLSearchParams(window.location.search);
+const userId = params.get('user_id');
+
+let isFollowing = false;
 
 async function fetchUserData() {
   try {
@@ -18,8 +24,42 @@ async function fetchUserData() {
       },
     });
     const data1 = await response1.json();
+    if (userId === String(data1.user_id)) {
+      // 현재 페이지 방문자가 로그인된 사용자인 경우
+      console.log('사용자는 자신의 페이지를 방문했습니다.');
+      document.querySelector('.edit-btn').style.display = 'block';
+      document.querySelector('.follow-btn').style.display = 'none';
+      document.querySelector('.like-list-btn').style.display = 'block';
+    } else {
+      // 다른 사용자가 페이지를 방문한 경우
+      console.log('다른 사용자가 페이지를 방문했습니다.');
+      document.querySelector('.follow-btn').style.display = 'block';
+      document.querySelector('.edit-btn').style.display = 'none';
+      document.querySelector('.like-list-btn').style.display = 'none';
 
-    userId = data1.user_id;
+      const followGetResponse = await fetch(`${BASEURL}/users/${userId}/following`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+      });
+
+      const followGetData = await followGetResponse.json();
+      followGetData.forEach((data) => {
+        console.log(data);
+        if (data.to_user === data1.user_id) {
+          followButton.textContent = '팔로우 취소';
+          isFollowing = true;
+        } else {
+          followButton.textContent = '팔로우 하기';
+          isFollowing = false;
+        }
+      });
+    }
+
+    followersLink.href = `./followers.html?user_id=${userId}`;
+    followsingsLink.href = `./followings.html?user_id=${userId}`;
 
     // 두 번째 fetch 요청
     const response2 = await fetch(`${BASEURL}/users/${userId}`, {
@@ -31,14 +71,16 @@ async function fetchUserData() {
     });
     const data2 = await response2.json();
 
-    const imageUrl = data2.profile_img.includes('k.kakaocdn.net') ?
-      data2.profile_img.replace('/media/http%3A/', 'http://') : data2.profile_img;
-
     nicknameBox.textContent = data2.nickname;
     followerNum.textContent = data2.followers_count;
     followingNum.textContent = data2.following_count;
     introBox.textContent = data2.bio ? data2.bio : '자기소개가 없습니다.';
-    profileImage.style.backgroundImage = `url(${imageUrl})`;
+
+    if (data2.profile_img) {
+      const imageUrl = data2.profile_img.includes('k.kakaocdn.net') ?
+        data2.profile_img.replace('/media/http%3A/', 'http://') : data2.profile_img;
+      profileImage.style.backgroundImage = `url(${imageUrl})`;
+    }
 
     // 세 번째 fetch 요청
     const response3 = await fetch(`${BASEURL}/trend-missions/${userId}`, {
@@ -55,7 +97,7 @@ async function fetchUserData() {
       const listItem = document.createElement('li');
       const link = document.createElement('a');
 
-      link.href = `trend_mission.html?trend_id=${data.trend}`; // 링크의 href 설정
+      link.href = `trend_mission.html?trend_mission_id=${data.id}&trend_name=${data.trend_name}&user_id=${data.user}`; // 링크의 href 설정
       link.textContent = data.trend_name; // 링크의 텍스트 설정
 
       listItem.appendChild(link); // 링크를 리스트 아이템에 추가
@@ -70,13 +112,33 @@ async function fetchUserData() {
 fetchUserData();
 
 document.querySelector('.edit-btn').addEventListener('click', () => {
-  location.href = `edit_user.html?user=${userId}`;
+  location.href = `edit_user.html?user_id=${userId}`;
+});
+
+document.querySelector('.follow-btn').addEventListener('click', async () => {
+  const followResponse = await fetch(`${BASEURL}/users/${userId}/following`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+  });
+  const followData = await followResponse.json();
+  console.log(followData)
+  if (followData.message === '팔로잉 취소 완료') {
+    isFollowing = false;
+  } else {
+    isFollowing = true;
+  }
+  console.log(isFollowing);
+  followButton.textContent = isFollowing ? '팔로우 취소' : '팔로우 하기';
+  followerNum.textContent = isFollowing ? Number(followerNum.textContent) + 1 : Number(followerNum.textContent) - 1;
 });
 
 document.querySelector('.stamp-btn').addEventListener('click', () => {
-  location.href = `my_stamp.html?user=${userId}`;
+  location.href = `my_stamp.html?user_id=${userId}`;
 });
 
 document.querySelector('.like-list-btn').addEventListener('click', () => {
-  location.href = `like_trends.html?user=${userId}`;
+  location.href = `like_trends.html?user_id=${userId}`;
 });

--- a/src/pages/user.html
+++ b/src/pages/user.html
@@ -55,6 +55,7 @@
             </ul>
             <!-- 프로필 수정 -->
             <button class="btn edit-btn">프로필 수정</button>
+            <button class="btn follow-btn">팔로우 하기</button>
           </div>
         </div>
         <!-- 자기소개 -->


### PR DESCRIPTION
- 기능
  - 상단 프로필 요청에 실패하면 로그인화면으로 이동, 상단 프로필 이미지는 값이 존재할때만 처리
  - 자신의 프로필과 다른 사람의 프로필 조회 가능, 다른 사람 프로필에서 팔로우 요청 가능
  - 프로필 이미지는 값이 있을때만 처리
  - 사용자 미션 아이템 링크 경로 변경
  - 프로필 수정, 스탬프 확인하기, 좋아요한 트렌드,팔로잉/팔로우 보기 링크 변경 (user ->  user_id로 변경)

- 비고
   - 팔로잉 조회에서 팔로잉 상태가 확인이 안되어 한 번 팔로우 요청한 상태이후로 새로고침하면 팔로우 취소 문구가 뜨게 됨